### PR TITLE
Added helpful links to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,22 @@
 orgmode for Sublime Text 2 & 3
 =============
 
-Handles .org files. Supported features is listed in README.org
+Adds support for [Org mode](http://orgmode.org)'s [.org syntax](http://orgmode.org/worg/dev/org-syntax.html) files to Sublime Text.
 
 Tested **on Windows 7 and Ubuntu 12.04 and Mac OS X 10.7.5** with Sublime Text 2 & 3
 
 
 Features
 =============
+
+_Full feature list available in [install.org](messages/install.org#features) or via the Sublime Text menus at Package Settings -> orgmode -> Readme.org_
+
 ![Features](https://raw.github.com/danielmagnussons/orgmode/master/images/screenshot1.png)
 
 
 Todo
 =============
+_Full todo list available in [install.org](https://github.com/danielmagnussons/orgmode/blob/master/messages/install.org) or via the Sublime Text menus at Package Settings -> orgmode -> Readme.org_
 ![Todo](https://raw.github.com/danielmagnussons/orgmode/master/images/screenshot2.png)
 More Todo in Sublime Text 2/Packages/README.org
 


### PR DESCRIPTION
Added links to the README to:
- the feature list on github
- the todo list on github
- orgmode's homepage and syntax definition

As well as some explanatory text re: opening `Readme.org` once the package is installed.
