### PR TITLE
Fix path to orgmode-store.bin.gz

### DIFF
--- a/orgmode_store.py
+++ b/orgmode_store.py
@@ -1,6 +1,6 @@
 from gzip import GzipFile
 from os import makedirs
-from os.path import dirname
+from os.path import dirname, join, abspath
 from pickle import load, dump
 import sublime
 import sublime_plugin
@@ -11,8 +11,10 @@ class OrgmodeStore(sublime_plugin.EventListener):
     def __init__(self, *args, **kwargs):
         self.debug = False
         self.db = {}
-        self.store = dirname(
-            sublime.packages_path()) + '/Settings/orgmode-store.bin.gz'
+        self.store = join(
+            abspath(sublime.packages_path()),
+            'Settings',
+            'orgmode-store.bin.gz')
         try:
             makedirs(dirname(self.store))
         except:


### PR DESCRIPTION
sublime.packages_path() returns a directory, there's no need to use dirname on it:

``` pycon
>>> sublime.packages_path()
'/Users/jiffyclub/Library/Application Support/Sublime Text 3/Packages'
```

os.path.join is a better way to construct system paths, abspath ensures we have an absolute path.

I think this should fix #38, though I'm not totally sure how to trigger the error in the first place. Note that I'm using a Mac so I don't know if this could break other systems.
