### PR TITLE
Added tri-state checkboxes to conform to Emacs' org mode checkboxes

### DIFF
--- a/orgmode.tmLanguage
+++ b/orgmode.tmLanguage
@@ -59,7 +59,7 @@
 			<key>name</key>
 			<string>orgmode.checkbox</string>
 			<key>match</key>
-			<string>(\[[xX ]\])\s?</string>
+			<string>(\[[xX\- ]\])\s?</string>
 		</dict>
 		<dict>
 			<key>name</key>


### PR DESCRIPTION
Some internal API changes as a result, but now a checkbox list performs as Emacs' orgmode checkboxes do.

This fixes an orgmode file import issue from my emacs install to sublime text where indeterminate checkboxes (a checkbox is marked as indeterminate "[-]" to indicate not all children are checked) are present.  As well as fixing the import, I've also ported the functionality of indeterminate checkboxes into checkbox lists.

Behaviour:
- Added indeterminate state checkboxes for situations where some child checkboxes are checked, but not all.
- Checking a child checkbox where all children are already unchecked will cause the parent checkbox to be marked as indeterminate.
- Checking a child checkbox where there are already children checked (but not all) will cause the parent to remain indeterminate.
- An indeterminate state checkbox will not count as checked, and so doesn't count as such in summaries.
- Toggling an indeterminate checkbox will check it (and all children).

I'm not a python programmer (C/C++ is more my thing), so this may be a little un-python-like, sorry.
